### PR TITLE
Move dex init amounts to tokens config file

### DIFF
--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -48,7 +48,7 @@ const scaffoldConfig = {
    */
   walletAutoConnect: true,
 
-  saltToken: { contractName: "SaltToken", name: "Salt", emoji: "💸", initAssetAmount: "", initCreditAmount: "" },
+  saltToken: { contractName: "SaltToken", name: "Salt", emoji: "💸" },
   tokens: tokensConfig,
   tokenLeaderboardPollingInterval: 60000,
   showChart: false,

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -48,7 +48,7 @@ const scaffoldConfig = {
    */
   walletAutoConnect: true,
 
-  saltToken: { contractName: "SaltToken", name: "Salt", emoji: "💸" },
+  saltToken: { contractName: "SaltToken", name: "Salt", emoji: "💸", initAssetAmount: "", initCreditAmount: "" },
   tokens: tokensConfig,
   tokenLeaderboardPollingInterval: 60000,
   showChart: false,

--- a/packages/nextjs/tokens.config.ts
+++ b/packages/nextjs/tokens.config.ts
@@ -3,12 +3,18 @@ import { TTokenInfo } from "./types/wallet";
 export type TokensConfig = TTokenInfo[];
 
 const tokensConfig = [
-  { contractName: "AvocadoToken", name: "Avocado", emoji: "🥑" },
-  { contractName: "BananaToken", name: "Banana", emoji: "🍌" },
-  { contractName: "TomatoToken", name: "Tomato", emoji: "🍅" },
-  { contractName: "StrawberryToken", name: "Strawberry", emoji: "🍓" },
-  { contractName: "AppleToken", name: "Apple", emoji: "🍏" },
-  { contractName: "LemonToken", name: "Lemon", emoji: "🍋" },
+  { contractName: "AvocadoToken", name: "Avocado", emoji: "🥑", initAssetAmount: "1000", initCreditAmount: "1000" },
+  { contractName: "BananaToken", name: "Banana", emoji: "🍌", initAssetAmount: "1000", initCreditAmount: "1000" },
+  { contractName: "TomatoToken", name: "Tomato", emoji: "🍅", initAssetAmount: "1000", initCreditAmount: "1000" },
+  {
+    contractName: "StrawberryToken",
+    name: "Strawberry",
+    emoji: "🍓",
+    initAssetAmount: "1000",
+    initCreditAmount: "1000",
+  },
+  { contractName: "AppleToken", name: "Apple", emoji: "🍏", initAssetAmount: "1000", initCreditAmount: "1000" },
+  { contractName: "LemonToken", name: "Lemon", emoji: "🍋", initAssetAmount: "1000", initCreditAmount: "1000" },
 ] satisfies TokensConfig;
 
 export default tokensConfig;

--- a/packages/nextjs/types/wallet.d.ts
+++ b/packages/nextjs/types/wallet.d.ts
@@ -2,6 +2,8 @@ export type TTokenInfo = {
   contractName: string;
   name: string;
   emoji: string;
+  initAssetAmount: string;
+  initCreditAmount: string;
 };
 
 export type TTokenBalance = {

--- a/packages/nextjs/types/wallet.d.ts
+++ b/packages/nextjs/types/wallet.d.ts
@@ -2,8 +2,8 @@ export type TTokenInfo = {
   contractName: string;
   name: string;
   emoji: string;
-  initAssetAmount: string;
-  initCreditAmount: string;
+  initAssetAmount?: string;
+  initCreditAmount?: string;
 };
 
 export type TTokenBalance = {


### PR DESCRIPTION
## Description

- Upgrade BasicDex::init to take two parameters (assetAmount, creditAmount) so ratios other than 1:1 are possible.
- Extend `TTokenInfo` type to include `initAssetAmount` and `initCreditAmount`.
- Remove hardcoded init values from `00_deploy_your_contract.ts` and instead read previously mentions `initAssetAmount` nd `initCreditAmount` from token config file